### PR TITLE
Update ExecStart

### DIFF
--- a/keepwsl.service
+++ b/keepwsl.service
@@ -2,7 +2,7 @@
 Description=keepwsl.service
 
 [Service]
-ExecStart=/mnt/c/Windows/System32/wsl.exe sleep infinity
+ExecStart=/mnt/c/Windows/System32/wsl.exe --exec sh -c "sleep infinity"
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Closes #1 

Modified the `ExecStart` command to explicitly use `sh` instead of relying on the user's default shell.

